### PR TITLE
Optimize script by having awk directly read from file and Improve sorting efficiency with parallel processing

### DIFF
--- a/Tasks/Unix tools practice/README.md
+++ b/Tasks/Unix tools practice/README.md
@@ -7,7 +7,7 @@ In this task I will use unix tools to manipulate the nginx access log and save t
 ### 1- Top 5 visited pages
 
 ```bash
-cat access.log | awk '{print $7}' | sort | uniq -c | sort -n -r | head -n 5 > "1- top visited pages.txt"
+awk '{print $7}' access.log | sort | uniq -c | sort --parallel=$(nproc) -n -r | head -n 5 > "1- top visited pages.txt"
 ```
 
 ### 2- Top 5 visited pages except '*'


### PR DESCRIPTION
### Skip Using `cat`
- Instead of using `cat` to pass the file content to `awk`, you can directly provide the file name to `awk` which is more efficient for large files.

### Parallel Sorting 
 - If you're working with extremely large log files, the sorting step can become a bottleneck. 
 - `sort` supports parallel sorting with the `--parallel option`, which can speed up the operation by using multiple cores.
 - The `$(nproc)` command dynamically fetches the number of available CPU cores to optimize parallel processing.

> [!NOTE]
I made these simple modifications to the first script only,
You can test these modifications and make sure whether they work well or not. If they are suitable for you, you can merge them and change the rest of the scripts if you wish.
